### PR TITLE
Use separate initial_user

### DIFF
--- a/group_vars.sample/common/vars
+++ b/group_vars.sample/common/vars
@@ -3,3 +3,5 @@
 user_name: myuser
 user_password: "{{ vault_user_password |password_hash('sha512')}}"
 user_ssh_pubkey: ssh-rsa <your SSH public key goes here>
+ansible_user: "{{ user_name }}"
+initial_user: root

--- a/init.yml
+++ b/init.yml
@@ -1,6 +1,7 @@
 ---
 
 - hosts: boxes
-  remote_user: root
+  vars:
+    - ansible_ssh_user: "{{ initial_user }}"
   roles:
     - common


### PR DESCRIPTION
This allows the init script to run as root by overriding the default
ansible_user
